### PR TITLE
change name for room num to match actual model

### DIFF
--- a/db.md
+++ b/db.md
@@ -43,7 +43,7 @@ Room
   dorm: (Dorm id)
   suite: (Suite id)
   floor: int
-  room_num: str
+  number: str
   capacity: int
 
   belongs_to: Suite


### PR DESCRIPTION
The name of the room number attribute for Rooms differ in the docs and the actual database model.